### PR TITLE
Fix MCP logging compatibility v0.1.2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,9 @@ Semantic Scholar APIをMCP（Model Context Protocol）経由でClaude Desktopか
 ### 開発者コミュニケーション
 - 絵文字使うのやめて．きもい
 
+### 開発環境
+- pipとpythonは使うな.
+
 ### テスト状況 (2025-07-08)
 #### 修復完了
 - **元のテストスイート**: 31個中31個 = 100%成功 ✓
@@ -215,6 +218,12 @@ mv tests/test_real_api.py.disabled tests/test_real_api.py
 - **PyPI**: https://pypi.org/project/semantic-scholar-mcp/
 - **TestPyPI**: https://test.pypi.org/project/semantic-scholar-mcp/
 - **インストール**: `pip install semantic-scholar-mcp`
+- **最新バージョン**: v0.1.1 (2025-07-08)
+
+### PyPI確認方法
+- **パッケージページ**: https://pypi.org/project/semantic-scholar-mcp/
+- **バージョン履歴**: https://pypi.org/project/semantic-scholar-mcp/#history
+- **作者情報**: https://pypi.org/project/semantic-scholar-mcp/#description
 
 ### GitHub Actions ワークフロー
 - **test-pypi.yml**: TestPyPIへの公開（すべてのプッシュで実行）

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "semantic-scholar-mcp"
-version = "0.1.1"
+version = "0.1.2"
 description = "MCP server for Semantic Scholar API integration"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/core/logging.py
+++ b/src/core/logging.py
@@ -169,8 +169,8 @@ class LoggerFactory:
         else:
             formatter = TextFormatter(self.config.include_context)
 
-        # Console handler
-        console_handler = logging.StreamHandler(sys.stdout)
+        # Console handler (stderr for MCP compatibility)
+        console_handler = logging.StreamHandler(sys.stderr)
         console_handler.setFormatter(formatter)
         root_logger.addHandler(console_handler)
 

--- a/src/semantic_scholar_mcp/__init__.py
+++ b/src/semantic_scholar_mcp/__init__.py
@@ -1,6 +1,6 @@
 """Semantic Scholar MCP server package."""
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 
 from .server import main
 

--- a/src/semantic_scholar_mcp/server.py
+++ b/src/semantic_scholar_mcp/server.py
@@ -38,7 +38,11 @@ async def initialize_server():
     # Load configuration
     config = get_config()
 
-    # Initialize logging
+    # Initialize logging with MCP-safe settings
+    import os
+    if os.getenv("MCP_MODE", "false").lower() == "true":
+        # Disable most logging for MCP compatibility
+        config.logging.level = "ERROR"
     initialize_logging(config.logging)
 
     # Create cache

--- a/uv.lock
+++ b/uv.lock
@@ -1568,7 +1568,7 @@ wheels = [
 
 [[package]]
 name = "semantic-scholar-mcp"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
- Fix log output to stderr for MCP JSON-RPC compatibility
- Add MCP_MODE environment variable to control logging level
- Update to version 0.1.2

This resolves JSON-RPC validation errors caused by log messages interfering with stdout.