### PR TITLE
Fix workflow permissions for Git operations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
+      contents: write
     steps:
       - uses: actions/checkout@v4
       


### PR DESCRIPTION
## Summary
• Add contents: write permission to PyPI release workflow
• Fix exit code 128 (Git permission error) in tag creation step
• Enable automatic tag creation and PyPI releases

## Problem
Workflow was failing with exit code 128 due to insufficient Git permissions for tag creation and push operations.

## Solution
Added `contents: write` permission to allow Git operations in the workflow.

🤖 Generated with [Claude Code](https://claude.ai/code)